### PR TITLE
Implement feature to recall commands

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -3,6 +3,7 @@ package seedu.address.ui;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -15,6 +16,7 @@ public class CommandBox extends UiPart<Region> {
 
     public static final String ERROR_STYLE_CLASS = "error";
     private static final String FXML = "CommandBox.fxml";
+    private static final CommandHistory COMMAND_HISTORY = new CommandHistory();
 
     private final CommandExecutor commandExecutor;
 
@@ -30,6 +32,44 @@ public class CommandBox extends UiPart<Region> {
 
         // Calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+
+        commandTextField.addEventFilter(KeyEvent.KEY_PRESSED, (KeyEvent event) -> {
+            switch (event.getCode()) {
+            case UP:
+                recallPreviousCommand();
+                event.consume();
+                break;
+            case DOWN:
+                recallNextCommand();
+                event.consume();
+                break;
+            default:
+                // Do not filter other key presses.
+            }
+        });
+    }
+
+    /**
+     * Recalls the previous valid command executed by the application.
+     */
+    private void recallPreviousCommand() {
+        if (COMMAND_HISTORY.hasPrevious()) {
+            commandTextField.setText(COMMAND_HISTORY.getPrevious(commandTextField.getText()));
+            commandTextField.positionCaret(commandTextField.getText().length());
+        }
+    }
+
+    /**
+     * Recalls the next valid command executed by the application.
+     */
+    private void recallNextCommand() {
+        if (COMMAND_HISTORY.hasNext()) {
+            commandTextField.setText(COMMAND_HISTORY.getNext());
+            commandTextField.positionCaret(commandTextField.getText().length());
+        } else if (COMMAND_HISTORY.hasCached()) {
+            commandTextField.setText(COMMAND_HISTORY.getCached());
+            commandTextField.positionCaret(commandTextField.getText().length());
+        }
     }
 
     /**
@@ -39,6 +79,7 @@ public class CommandBox extends UiPart<Region> {
     private void handleCommandEntered() {
         try {
             commandExecutor.execute(commandTextField.getText());
+            COMMAND_HISTORY.addHistory(commandTextField.getText());
             commandTextField.setText("");
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,10 +1,13 @@
 package seedu.address.ui;
 
+import java.util.logging.Logger;
+
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -17,6 +20,8 @@ public class CommandBox extends UiPart<Region> {
     public static final String ERROR_STYLE_CLASS = "error";
     private static final String FXML = "CommandBox.fxml";
     private static final CommandHistory COMMAND_HISTORY = new CommandHistory();
+
+    private final Logger logger = LogsCenter.getLogger(CommandBox.class);
 
     private final CommandExecutor commandExecutor;
 
@@ -36,10 +41,12 @@ public class CommandBox extends UiPart<Region> {
         commandTextField.addEventFilter(KeyEvent.KEY_PRESSED, (KeyEvent event) -> {
             switch (event.getCode()) {
             case UP:
+                logger.fine("UP key pressed");
                 recallPreviousCommand();
                 event.consume();
                 break;
             case DOWN:
+                logger.fine("DOWN key pressed");
                 recallNextCommand();
                 event.consume();
                 break;
@@ -55,6 +62,7 @@ public class CommandBox extends UiPart<Region> {
     private void recallPreviousCommand() {
         if (COMMAND_HISTORY.hasPrevious()) {
             commandTextField.setText(COMMAND_HISTORY.getPrevious(commandTextField.getText()));
+            logger.fine("Recalled: " + commandTextField.getText());
             commandTextField.positionCaret(commandTextField.getText().length());
         }
     }
@@ -65,9 +73,11 @@ public class CommandBox extends UiPart<Region> {
     private void recallNextCommand() {
         if (COMMAND_HISTORY.hasNext()) {
             commandTextField.setText(COMMAND_HISTORY.getNext());
+            logger.fine("Recalled: " + commandTextField.getText());
             commandTextField.positionCaret(commandTextField.getText().length());
         } else if (COMMAND_HISTORY.hasCached()) {
             commandTextField.setText(COMMAND_HISTORY.getCached());
+            logger.fine("Retrieved from cache: " + commandTextField.getText());
             commandTextField.positionCaret(commandTextField.getText().length());
         }
     }

--- a/src/main/java/seedu/address/ui/CommandHistory.java
+++ b/src/main/java/seedu/address/ui/CommandHistory.java
@@ -6,6 +6,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
 
 /**
  * Represents a stack of commands executed by the user.
@@ -13,6 +16,7 @@ import java.util.Optional;
  */
 public class CommandHistory {
 
+    private final Logger logger = LogsCenter.getLogger(CommandHistory.class);
     private final List<String> history;
     private int pointer;
     private Optional<String> cache;
@@ -33,6 +37,7 @@ public class CommandHistory {
     public void addHistory(String command) {
         requireNonNull(command);
 
+        logger.info("Stored in command recall: " + command);
         history.add(command);
         pointer = history.size();
         cache = Optional.empty();
@@ -86,6 +91,7 @@ public class CommandHistory {
      */
     public String getPrevious(String currentInput) throws IndexOutOfBoundsException {
         if (pointer == history.size()) {
+            logger.fine("Cached: " + currentInput);
             cache = Optional.of(currentInput);
         }
         return history.get(--pointer);

--- a/src/main/java/seedu/address/ui/CommandHistory.java
+++ b/src/main/java/seedu/address/ui/CommandHistory.java
@@ -1,0 +1,93 @@
+package seedu.address.ui;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+/**
+ * Represents a stack of commands executed by the user.
+ * Supports caching the current command before starting to traverse the stack from the top.
+ */
+public class CommandHistory {
+
+    private final List<String> history;
+    private int pointer;
+    private Optional<String> cache;
+
+    /**
+     * Creates a new {@code CommandHistory} instance.
+     */
+    public CommandHistory() {
+        history = new ArrayList<>();
+        pointer = 0;
+        cache = Optional.empty();
+    }
+
+    /**
+     * Adds the {@code command} to stack and resets the position of the pointer to above the stack.
+     * Empties the cache.
+     */
+    public void addHistory(String command) {
+        requireNonNull(command);
+
+        history.add(command);
+        pointer = history.size();
+        cache = Optional.empty();
+    }
+
+    /**
+     * Returns true if there is a next command that can be recalled.
+     */
+    public boolean hasNext() {
+        return history.size() > 0 && pointer < history.size() - 1;
+    }
+
+    /**
+     * Returns true if there is a previous command that can be recalled.
+     */
+    public boolean hasPrevious() {
+        return history.size() > 0 && pointer > 0;
+    }
+
+    /**
+     * Returns true if there is a cached command.
+     */
+    public boolean hasCached() {
+        return cache.isPresent();
+    }
+
+    /**
+     * Returns the currently cached command and moves the pointer above the stack.
+     *
+     * @throws NoSuchElementException if there is no cached value.
+     */
+    public String getCached() throws NoSuchElementException {
+        pointer = history.size();
+        return cache.get();
+    }
+
+    /**
+     * Returns the next command.
+     *
+     * @throws IndexOutOfBoundsException if there is no next command to recall.
+     */
+    public String getNext() throws IndexOutOfBoundsException {
+        return history.get(++pointer);
+    }
+
+    /**
+     * Returns the previous command.
+     * Caches the {@code currentInput} if the pointer is above the stack.
+     *
+     * @throws IndexOutOfBoundsException if there is no previous command to recall.
+     */
+    public String getPrevious(String currentInput) throws IndexOutOfBoundsException {
+        if (pointer == history.size()) {
+            cache = Optional.of(currentInput);
+        }
+        return history.get(--pointer);
+    }
+}

--- a/src/test/java/seedu/address/ui/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/ui/CommandHistoryTest.java
@@ -1,0 +1,119 @@
+package seedu.address.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.Test;
+
+public class CommandHistoryTest {
+
+    private static final String CACHE = "Cache";
+    private static final String PREVIOUS = "Previous";
+    private static final String COMMAND_1 = "Command 1";
+    private static final String COMMAND_2 = "Command 2";
+
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void constructor_cleanState() {
+        CommandHistory commandHistoryTest = new CommandHistory();
+        assertFalse(commandHistoryTest.hasPrevious());
+        assertFalse(commandHistoryTest.hasNext());
+        assertFalse(commandHistoryTest.hasCached());
+    }
+
+    @Test
+    public void addHistory_null_throwNullPointerException() {
+        assertThrows(NullPointerException.class, () -> commandHistory.addHistory(null));
+    }
+
+    @Test
+    public void addHistory_validString_success() {
+        commandHistory.addHistory(PREVIOUS);
+        assertTrue(commandHistory.hasPrevious());
+        assertEquals(PREVIOUS, commandHistory.getPrevious(CACHE));
+    }
+
+    @Test
+    public void addHistory_validString_resetsCache() {
+        commandHistory.addHistory(PREVIOUS);
+        commandHistory.getPrevious(CACHE);
+        assertEquals(CACHE, commandHistory.getCached());
+
+        commandHistory.addHistory(COMMAND_1);
+        assertFalse(commandHistory.hasCached());
+    }
+
+    @Test
+    public void getPrevious_nullString_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> commandHistory.getPrevious(null));
+    }
+
+    @Test
+    public void getPrevious_noPrevious_throwsIndexOutOfBoundsException() {
+        assertThrows(IndexOutOfBoundsException.class, () -> commandHistory.getPrevious(CACHE));
+    }
+
+    @Test
+    public void getPrevious_hasPrevious_returnsPreviousAndDecrementsPointer() {
+        commandHistory.addHistory(PREVIOUS);
+        assertEquals(PREVIOUS, commandHistory.getPrevious(CACHE));
+        assertFalse(commandHistory.hasPrevious());
+    }
+
+    @Test
+    public void getPrevious_outsideStack_storesCache() {
+        // setup previous history
+        commandHistory.addHistory(PREVIOUS);
+        assertFalse(commandHistory.hasNext());
+
+        commandHistory.getPrevious(CACHE);
+        assertEquals(CACHE, commandHistory.getCached());
+    }
+
+    @Test
+    public void getNext_noNext_throwsIndexOutOfBoundsException() {
+        assertThrows(IndexOutOfBoundsException.class, () -> commandHistory.getNext());
+    }
+
+    @Test
+    public void getNext_hasNext_returnsNextAndIncrementsPointer() {
+        commandHistory.addHistory(COMMAND_1);
+        commandHistory.addHistory(COMMAND_2);
+        commandHistory.getPrevious(CACHE);
+        commandHistory.getPrevious(CACHE);
+        assertTrue(commandHistory.hasNext(), "Test precondition error: no next command was found.");
+
+        assertEquals(COMMAND_2, commandHistory.getNext());
+        assertFalse(commandHistory.hasNext());
+    }
+
+    @Test
+    public void getNext_retainsCache() {
+        commandHistory.addHistory(COMMAND_1);
+        commandHistory.addHistory(COMMAND_2);
+        commandHistory.getPrevious(CACHE);
+        commandHistory.getPrevious(CACHE);
+
+        commandHistory.getNext();
+        assertEquals(CACHE, commandHistory.getCached());
+    }
+
+    @Test
+    public void getCache_noCache_throwsNoSuchElementException() {
+        assertThrows(NoSuchElementException.class, () -> commandHistory.getCached());
+    }
+
+    @Test
+    public void getCache_hasCache_restoresPointerToAboveStack() {
+        commandHistory.addHistory(COMMAND_1);
+        commandHistory.getPrevious(CACHE);
+        commandHistory.getCached();
+
+        assertFalse(commandHistory.hasNext());
+    }
+}

--- a/src/test/java/seedu/address/ui/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/ui/CommandHistoryTest.java
@@ -40,6 +40,7 @@ public class CommandHistoryTest {
 
     @Test
     public void addHistory_validString_resetsCache() {
+        // setup previous history and cache
         commandHistory.addHistory(PREVIOUS);
         commandHistory.getPrevious(CACHE);
         assertEquals(CACHE, commandHistory.getCached());
@@ -82,6 +83,7 @@ public class CommandHistoryTest {
 
     @Test
     public void getNext_hasNext_returnsNextAndIncrementsPointer() {
+        // setup previous history
         commandHistory.addHistory(COMMAND_1);
         commandHistory.addHistory(COMMAND_2);
         commandHistory.getPrevious(CACHE);
@@ -94,6 +96,7 @@ public class CommandHistoryTest {
 
     @Test
     public void getNext_retainsCache() {
+        // setup previous history
         commandHistory.addHistory(COMMAND_1);
         commandHistory.addHistory(COMMAND_2);
         commandHistory.getPrevious(CACHE);
@@ -110,10 +113,11 @@ public class CommandHistoryTest {
 
     @Test
     public void getCache_hasCache_restoresPointerToAboveStack() {
+        // setup previous history
         commandHistory.addHistory(COMMAND_1);
         commandHistory.getPrevious(CACHE);
-        commandHistory.getCached();
 
+        commandHistory.getCached();
         assertFalse(commandHistory.hasNext());
     }
 }


### PR DESCRIPTION
Resolves #133 

Introduces a feature that allows users to recall past commands using the `up` and `down` arrow keys when in the command box.

Specifications are as follows:
1. If there is no command to recall, no changes to cursor or text field.
2. If the current command is a fresh command (i.e. not edited from a recalled command), it will be cached when recalling past commands.
3. When at the oldest command, any attempts to back further in the past will result in no changes to the cursor or text field.
4. When at the newest recorded command, the `down` arrow key will recall the cached command.