### PR TITLE
Implement parser and command support for displaying venue

### DIFF
--- a/src/main/java/tutorspet/logic/commands/DisplayVenueCommand.java
+++ b/src/main/java/tutorspet/logic/commands/DisplayVenueCommand.java
@@ -1,0 +1,76 @@
+package tutorspet.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static tutorspet.commons.core.Messages.MESSAGE_INVALID_LESSON_DISPLAYED_INDEX;
+import static tutorspet.commons.core.Messages.MESSAGE_INVALID_MODULE_CLASS_DISPLAYED_INDEX;
+import static tutorspet.commons.util.CollectionUtil.requireAllNonNull;
+import static tutorspet.logic.parser.CliSyntax.PREFIX_CLASS_INDEX;
+import static tutorspet.logic.parser.CliSyntax.PREFIX_LESSON_INDEX;
+
+import java.util.List;
+
+import tutorspet.commons.core.index.Index;
+import tutorspet.logic.commands.exceptions.CommandException;
+import tutorspet.model.Model;
+import tutorspet.model.lesson.Lesson;
+import tutorspet.model.moduleclass.ModuleClass;
+
+/**
+ * Displays the venue for a specified lesson in a specified class in the student manager.
+ */
+public class DisplayVenueCommand extends Command {
+
+    public static final String COMMAND_WORD = "display-venue";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + "Displays the venue for a lesson.\n"
+            + "Note: All indexes must be positive integers.\n"
+            + "Parameters: "
+            + PREFIX_CLASS_INDEX + "CLASS_INDEX "
+            + PREFIX_LESSON_INDEX + "LESSON_INDEX";
+
+    public static final String MESSAGE_SUCCESS = "Venue for %1$s %2$s:\n%3$s";
+
+    private final Index moduleClassIndex;
+    private final Index lessonIndex;
+
+    /**
+     * Creates a DisplayVenueCommand to display the venue for a specified lesson in a specified class
+     * in the student manager.
+     */
+    public DisplayVenueCommand(Index moduleClassIndex, Index lessonIndex) {
+        requireAllNonNull(moduleClassIndex, lessonIndex);
+
+        this.moduleClassIndex = moduleClassIndex;
+        this.lessonIndex = lessonIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        List<ModuleClass> lastShownModuleClassList = model.getFilteredModuleClassList();
+
+        if (moduleClassIndex.getOneBased() > lastShownModuleClassList.size()) {
+            throw new CommandException(MESSAGE_INVALID_MODULE_CLASS_DISPLAYED_INDEX);
+        }
+
+        ModuleClass targetModuleClass = lastShownModuleClassList.get(moduleClassIndex.getZeroBased());
+
+        if (lessonIndex.getOneBased() > targetModuleClass.getLessons().size()) {
+            throw new CommandException(MESSAGE_INVALID_LESSON_DISPLAYED_INDEX);
+        }
+
+        Lesson targetLesson = targetModuleClass.getLessons().get(lessonIndex.getZeroBased());
+        String message = String.format(MESSAGE_SUCCESS, targetModuleClass.getName().fullName,
+                targetLesson.printLesson(), targetLesson.getVenue());
+        return new CommandResult(message);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DisplayVenueCommand // instanceof handles nulls
+                && moduleClassIndex.equals(((DisplayVenueCommand) other).moduleClassIndex)
+                && lessonIndex.equals(((DisplayVenueCommand) other).lessonIndex));
+    }
+}

--- a/src/main/java/tutorspet/logic/commands/FindAttendanceCommand.java
+++ b/src/main/java/tutorspet/logic/commands/FindAttendanceCommand.java
@@ -1,6 +1,12 @@
 package tutorspet.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static tutorspet.commons.core.Messages.MESSAGE_INVALID_LESSON_DISPLAYED_INDEX;
+import static tutorspet.commons.core.Messages.MESSAGE_INVALID_MODULE_CLASS_DISPLAYED_INDEX;
+import static tutorspet.commons.core.Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX;
+import static tutorspet.commons.core.Messages.MESSAGE_INVALID_STUDENT_IN_MODULE_CLASS;
+import static tutorspet.commons.core.Messages.MESSAGE_INVALID_WEEK;
+import static tutorspet.commons.core.Messages.MESSAGE_MISSING_STUDENT_ATTENDANCE;
 import static tutorspet.commons.util.CollectionUtil.requireAllNonNull;
 import static tutorspet.logic.parser.CliSyntax.PREFIX_CLASS_INDEX;
 import static tutorspet.logic.parser.CliSyntax.PREFIX_LESSON_INDEX;
@@ -9,7 +15,6 @@ import static tutorspet.logic.parser.CliSyntax.PREFIX_WEEK;
 
 import java.util.List;
 
-import tutorspet.commons.core.Messages;
 import tutorspet.commons.core.index.Index;
 import tutorspet.logic.commands.exceptions.CommandException;
 import tutorspet.model.Model;
@@ -21,7 +26,7 @@ import tutorspet.model.moduleclass.ModuleClass;
 import tutorspet.model.student.Student;
 
 /**
- * Finds a student's attendance for a specified lesson in a specified lesson on
+ * Finds a student's attendance for a specified lesson in a specified class on
  * a specified week in the student manager.
  */
 public class FindAttendanceCommand extends Command {
@@ -32,12 +37,12 @@ public class FindAttendanceCommand extends Command {
             + "lesson on a specified week.\n"
             + "Note: All indexes and numbers must be positive integers.\n"
             + "Parameters: "
-            + PREFIX_CLASS_INDEX + "CLASS_INDEX"
+            + PREFIX_CLASS_INDEX + "CLASS_INDEX "
             + PREFIX_LESSON_INDEX + "LESSON_INDEX "
             + PREFIX_STUDENT_INDEX + "STUDENT_INDEX "
             + PREFIX_WEEK + "WEEK_NUMBER";
 
-    public static final String MESSAGE_SUCCESS = "%1$S attended week %2$s lesson with a participation score of %3$s";
+    public static final String MESSAGE_SUCCESS = "%1$s attended week %2$s lesson with a participation score of %3$s";
 
     private final Index moduleClassIndex;
     private final Index lessonIndex;
@@ -64,35 +69,35 @@ public class FindAttendanceCommand extends Command {
         List<Student> lastShownStudentList = model.getFilteredStudentList();
         List<ModuleClass> lastShownModuleClassList = model.getFilteredModuleClassList();
 
-        if (studentIndex.getZeroBased() >= lastShownStudentList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        if (studentIndex.getOneBased() > lastShownStudentList.size()) {
+            throw new CommandException(MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
         }
 
-        if (moduleClassIndex.getZeroBased() >= lastShownModuleClassList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_MODULE_CLASS_DISPLAYED_INDEX);
+        if (moduleClassIndex.getOneBased() > lastShownModuleClassList.size()) {
+            throw new CommandException(MESSAGE_INVALID_MODULE_CLASS_DISPLAYED_INDEX);
         }
 
         Student targetStudent = lastShownStudentList.get(studentIndex.getZeroBased());
         ModuleClass targetModuleClass = lastShownModuleClassList.get(moduleClassIndex.getZeroBased());
 
         if (!targetModuleClass.hasStudentUuid(targetStudent.getUuid())) {
-            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_IN_MODULE_CLASS);
+            throw new CommandException(MESSAGE_INVALID_STUDENT_IN_MODULE_CLASS);
         }
 
-        if (lessonIndex.getZeroBased() >= targetModuleClass.getLessons().size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_LESSON_DISPLAYED_INDEX);
+        if (lessonIndex.getOneBased() > targetModuleClass.getLessons().size()) {
+            throw new CommandException(MESSAGE_INVALID_LESSON_DISPLAYED_INDEX);
         }
 
         Lesson targetLesson = targetModuleClass.getLessons().get(lessonIndex.getZeroBased());
 
         if (!targetLesson.getAttendanceRecordList().isWeekContained(week)) {
-            throw new CommandException(Messages.MESSAGE_INVALID_WEEK);
+            throw new CommandException(MESSAGE_INVALID_WEEK);
         }
 
         AttendanceRecord attendanceRecord = targetLesson.getAttendanceRecordList().getAttendanceRecord(week);
 
         if (!attendanceRecord.hasAttendance(targetStudent.getUuid())) {
-            throw new CommandException(Messages.MESSAGE_MISSING_STUDENT_ATTENDANCE);
+            throw new CommandException(MESSAGE_MISSING_STUDENT_ATTENDANCE);
         }
 
         Attendance attendance = targetLesson.getAttendanceRecordList().getAttendance(targetStudent, week);

--- a/src/main/java/tutorspet/logic/parser/DisplayVenueCommandParser.java
+++ b/src/main/java/tutorspet/logic/parser/DisplayVenueCommandParser.java
@@ -1,0 +1,49 @@
+package tutorspet.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static tutorspet.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static tutorspet.logic.commands.DisplayVenueCommand.MESSAGE_USAGE;
+import static tutorspet.logic.parser.CliSyntax.PREFIX_CLASS_INDEX;
+import static tutorspet.logic.parser.CliSyntax.PREFIX_LESSON_INDEX;
+import static tutorspet.logic.parser.ParserUtil.arePrefixesPresent;
+import static tutorspet.logic.parser.ParserUtil.parseIndex;
+
+import tutorspet.commons.core.index.Index;
+import tutorspet.logic.commands.DisplayVenueCommand;
+import tutorspet.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DisplayVenueCommand object.
+ */
+public class DisplayVenueCommandParser implements Parser<DisplayVenueCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DisplayVenueCommand and
+     * returns a DisplayVenueCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format.
+     */
+    public DisplayVenueCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_CLASS_INDEX, PREFIX_LESSON_INDEX);
+
+        Index moduleClassIndex;
+        Index lessonIndex;
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_CLASS_INDEX, PREFIX_LESSON_INDEX)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        }
+
+        try {
+            moduleClassIndex = parseIndex(argMultimap.getValue(PREFIX_CLASS_INDEX).get());
+            lessonIndex = parseIndex(argMultimap.getValue(PREFIX_LESSON_INDEX).get());
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE), pe);
+        }
+
+        return new DisplayVenueCommand(moduleClassIndex, lessonIndex);
+    }
+}

--- a/src/main/java/tutorspet/logic/parser/FindAttendanceCommandParser.java
+++ b/src/main/java/tutorspet/logic/parser/FindAttendanceCommandParser.java
@@ -2,11 +2,13 @@ package tutorspet.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static tutorspet.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static tutorspet.logic.commands.FindAttendanceCommand.MESSAGE_USAGE;
 import static tutorspet.logic.parser.CliSyntax.PREFIX_CLASS_INDEX;
 import static tutorspet.logic.parser.CliSyntax.PREFIX_LESSON_INDEX;
 import static tutorspet.logic.parser.CliSyntax.PREFIX_STUDENT_INDEX;
 import static tutorspet.logic.parser.CliSyntax.PREFIX_WEEK;
 import static tutorspet.logic.parser.ParserUtil.arePrefixesPresent;
+import static tutorspet.logic.parser.ParserUtil.parseIndex;
 
 import tutorspet.commons.core.index.Index;
 import tutorspet.logic.commands.FindAttendanceCommand;
@@ -38,17 +40,16 @@ public class FindAttendanceCommandParser implements Parser<FindAttendanceCommand
         if (!arePrefixesPresent(argMultimap, PREFIX_CLASS_INDEX, PREFIX_LESSON_INDEX, PREFIX_STUDENT_INDEX,
                 PREFIX_WEEK)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    FindAttendanceCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
         }
 
         try {
-            moduleClassIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_CLASS_INDEX).get());
-            lessonIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_LESSON_INDEX).get());
-            studentIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_STUDENT_INDEX).get());
+            moduleClassIndex = parseIndex(argMultimap.getValue(PREFIX_CLASS_INDEX).get());
+            lessonIndex = parseIndex(argMultimap.getValue(PREFIX_LESSON_INDEX).get());
+            studentIndex = parseIndex(argMultimap.getValue(PREFIX_STUDENT_INDEX).get());
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindAttendanceCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE), pe);
         }
 
         Week week = ParserUtil.parseWeek(argMultimap.getValue(PREFIX_WEEK).get());

--- a/src/main/java/tutorspet/logic/parser/TutorsPetParser.java
+++ b/src/main/java/tutorspet/logic/parser/TutorsPetParser.java
@@ -17,6 +17,7 @@ import tutorspet.logic.commands.DeleteAttendanceCommand;
 import tutorspet.logic.commands.DeleteLessonCommand;
 import tutorspet.logic.commands.DeleteModuleClassCommand;
 import tutorspet.logic.commands.DeleteStudentCommand;
+import tutorspet.logic.commands.DisplayVenueCommand;
 import tutorspet.logic.commands.EditAttendanceCommand;
 import tutorspet.logic.commands.EditLessonCommand;
 import tutorspet.logic.commands.EditModuleClassCommand;
@@ -130,6 +131,9 @@ public class TutorsPetParser {
 
         case FindAttendanceCommand.COMMAND_WORD:
             return new FindAttendanceCommandParser().parse(arguments);
+
+        case DisplayVenueCommand.COMMAND_WORD:
+            return new DisplayVenueCommandParser().parse(arguments);
 
         case ViewHistoryCommand.COMMAND_WORD:
             return new ViewHistoryCommand();

--- a/src/main/java/tutorspet/model/lesson/Lesson.java
+++ b/src/main/java/tutorspet/model/lesson/Lesson.java
@@ -101,6 +101,13 @@ public class Lesson {
     }
 
     /**
+     * Returns a print friendly version of the {@code Lesson} object.
+     */
+    public String printLesson() {
+        return this.day.toString() + " " + this.startTime.toString() + " to " + this.endTime.toString();
+    }
+
+    /**
      * Returns true if both lessons have same start time, end time, day, number of occurrences and venue.
      * This defines a stronger notion of equality between two lessons.
      */

--- a/src/test/java/tutorspet/logic/commands/DisplayVenueCommandTest.java
+++ b/src/test/java/tutorspet/logic/commands/DisplayVenueCommandTest.java
@@ -1,0 +1,134 @@
+package tutorspet.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static tutorspet.commons.core.Messages.MESSAGE_INVALID_LESSON_DISPLAYED_INDEX;
+import static tutorspet.commons.core.Messages.MESSAGE_INVALID_MODULE_CLASS_DISPLAYED_INDEX;
+import static tutorspet.logic.commands.CommandTestUtil.assertCommandFailure;
+import static tutorspet.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static tutorspet.logic.commands.CommandTestUtil.showModuleClassAtIndex;
+import static tutorspet.logic.commands.DisplayVenueCommand.MESSAGE_SUCCESS;
+import static tutorspet.testutil.Assert.assertThrows;
+import static tutorspet.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
+import static tutorspet.testutil.TypicalIndexes.INDEX_THIRD_ITEM;
+import static tutorspet.testutil.TypicalTutorsPet.getTypicalTutorsPet;
+
+import org.junit.jupiter.api.Test;
+
+import tutorspet.commons.core.index.Index;
+import tutorspet.model.Model;
+import tutorspet.model.ModelManager;
+import tutorspet.model.UserPrefs;
+import tutorspet.model.lesson.Lesson;
+import tutorspet.model.moduleclass.ModuleClass;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code DisplayVenueCommand}.
+ */
+public class DisplayVenueCommandTest {
+
+    private final Model model = new ModelManager(getTypicalTutorsPet(), new UserPrefs());
+
+    @Test
+    public void constructor_nullIndexes_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new DisplayVenueCommand(null, INDEX_FIRST_ITEM));
+        assertThrows(NullPointerException.class, () -> new DisplayVenueCommand(INDEX_FIRST_ITEM, null));
+    }
+
+    @Test
+    public void execute_unfilteredList_success() {
+        Index moduleClassIndex = INDEX_FIRST_ITEM;
+        Index lessonIndex = INDEX_FIRST_ITEM;
+
+        assert moduleClassIndex.getZeroBased() < model.getFilteredModuleClassList().size();
+
+        ModuleClass moduleClass = model.getFilteredModuleClassList().get(moduleClassIndex.getZeroBased());
+
+        assert lessonIndex.getZeroBased() < moduleClass.getLessons().size();
+
+        Lesson lesson = moduleClass.getLessons().get(lessonIndex.getZeroBased());
+
+        assert moduleClass.hasLesson(lesson);
+
+        String expectedMessage = String.format(MESSAGE_SUCCESS, moduleClass.getName().fullName, lesson.printLesson(),
+                lesson.getVenue());
+        Model expectedModel = new ModelManager(model.getTutorsPet(), new UserPrefs());
+        DisplayVenueCommand displayVenueCommand = new DisplayVenueCommand(moduleClassIndex, lessonIndex);
+
+        assertCommandSuccess(displayVenueCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showModuleClassAtIndex(model, INDEX_FIRST_ITEM);
+
+        Index moduleClassIndex = INDEX_FIRST_ITEM;
+        Index lessonIndex = INDEX_FIRST_ITEM;
+
+        assert moduleClassIndex.getZeroBased() < model.getFilteredModuleClassList().size();
+
+        ModuleClass moduleClass = model.getFilteredModuleClassList().get(moduleClassIndex.getZeroBased());
+
+        assert lessonIndex.getZeroBased() < moduleClass.getLessons().size();
+
+        Lesson lesson = moduleClass.getLessons().get(lessonIndex.getZeroBased());
+
+        assert moduleClass.hasLesson(lesson);
+
+        String expectedMessage = String.format(MESSAGE_SUCCESS, moduleClass.getName().fullName, lesson.printLesson(),
+                lesson.getVenue());
+        Model expectedModel = new ModelManager(model.getTutorsPet(), new UserPrefs());
+        expectedModel.updateFilteredModuleClassList(c -> c.isSameModuleClass(moduleClass));
+
+        DisplayVenueCommand displayVenueCommand = new DisplayVenueCommand(moduleClassIndex, lessonIndex);
+
+        assertCommandSuccess(displayVenueCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidClassIndex_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredModuleClassList().size() + 1);
+        Index lessonIndex = INDEX_FIRST_ITEM;
+
+        DisplayVenueCommand displayVenueCommand = new DisplayVenueCommand(outOfBoundIndex, lessonIndex);
+
+        assertCommandFailure(displayVenueCommand, model, MESSAGE_INVALID_MODULE_CLASS_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidLessonIndex_failure() {
+        Index moduleClassIndex = INDEX_FIRST_ITEM;
+
+        assert moduleClassIndex.getZeroBased() < model.getFilteredModuleClassList().size();
+
+        ModuleClass moduleClass = model.getFilteredModuleClassList().get(moduleClassIndex.getZeroBased());
+        Index outOfBoundIndex = Index.fromOneBased(moduleClass.getLessons().size() + 1);
+
+        DisplayVenueCommand displayVenueCommand = new DisplayVenueCommand(moduleClassIndex, outOfBoundIndex);
+
+        assertCommandFailure(displayVenueCommand, model, MESSAGE_INVALID_LESSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DisplayVenueCommand displayVenueCommand = new DisplayVenueCommand(INDEX_FIRST_ITEM, INDEX_FIRST_ITEM);
+
+        // same object -> returns true
+        assertTrue(displayVenueCommand.equals(displayVenueCommand));
+
+        // same value -> returns true
+        DisplayVenueCommand duplicateDisplayVenueCommand = new DisplayVenueCommand(INDEX_FIRST_ITEM, INDEX_FIRST_ITEM);
+        assertTrue(displayVenueCommand.equals(duplicateDisplayVenueCommand));
+
+        // different type -> returns false
+        assertFalse(displayVenueCommand.equals(5));
+
+        // null -> returns false
+        assertFalse(displayVenueCommand.equals(null));
+
+        // different indexes -> returns false
+        DisplayVenueCommand displayVenueCommandDifferentIndex = new DisplayVenueCommand(INDEX_THIRD_ITEM,
+                INDEX_FIRST_ITEM);
+        assertFalse(displayVenueCommand.equals(displayVenueCommandDifferentIndex));
+    }
+}

--- a/src/test/java/tutorspet/logic/commands/FindAttendanceCommandTest.java
+++ b/src/test/java/tutorspet/logic/commands/FindAttendanceCommandTest.java
@@ -2,12 +2,19 @@ package tutorspet.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static tutorspet.commons.core.Messages.MESSAGE_INVALID_LESSON_DISPLAYED_INDEX;
+import static tutorspet.commons.core.Messages.MESSAGE_INVALID_MODULE_CLASS_DISPLAYED_INDEX;
+import static tutorspet.commons.core.Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX;
+import static tutorspet.commons.core.Messages.MESSAGE_INVALID_STUDENT_IN_MODULE_CLASS;
+import static tutorspet.commons.core.Messages.MESSAGE_INVALID_WEEK;
+import static tutorspet.commons.core.Messages.MESSAGE_MISSING_STUDENT_ATTENDANCE;
 import static tutorspet.logic.commands.CommandTestUtil.VALID_WEEK_1;
 import static tutorspet.logic.commands.CommandTestUtil.VALID_WEEK_5;
 import static tutorspet.logic.commands.CommandTestUtil.assertCommandFailure;
 import static tutorspet.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static tutorspet.logic.commands.CommandTestUtil.showModuleClassAtIndex;
 import static tutorspet.logic.commands.CommandTestUtil.showStudentAtIndex;
+import static tutorspet.logic.commands.FindAttendanceCommand.MESSAGE_SUCCESS;
 import static tutorspet.testutil.Assert.assertThrows;
 import static tutorspet.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 import static tutorspet.testutil.TypicalIndexes.INDEX_THIRD_ITEM;
@@ -15,7 +22,6 @@ import static tutorspet.testutil.TypicalTutorsPet.getTypicalTutorsPet;
 
 import org.junit.jupiter.api.Test;
 
-import tutorspet.commons.core.Messages;
 import tutorspet.commons.core.index.Index;
 import tutorspet.model.Model;
 import tutorspet.model.ModelManager;
@@ -56,8 +62,14 @@ public class FindAttendanceCommandTest {
         Index studentIndex = INDEX_FIRST_ITEM;
         Week targetWeek = VALID_WEEK_1;
 
+        assert moduleClassIndex.getZeroBased() < model.getFilteredModuleClassList().size();
+        assert studentIndex.getZeroBased() < model.getFilteredStudentList().size();
+
         ModuleClass moduleClass = model.getFilteredModuleClassList().get(moduleClassIndex.getZeroBased());
         Student student = model.getFilteredStudentList().get(studentIndex.getZeroBased());
+
+        assert lessonIndex.getZeroBased() < moduleClass.getLessons().size();
+
         Lesson lesson = moduleClass.getLessons().get(lessonIndex.getZeroBased());
 
         assert moduleClass.hasLesson(lesson);
@@ -65,7 +77,7 @@ public class FindAttendanceCommandTest {
         assert lesson.getAttendanceRecordList().hasAttendance(student, targetWeek);
 
         Attendance attendance = lesson.getAttendanceRecordList().getAttendance(student, targetWeek);
-        String expectedMessage = String.format(FindAttendanceCommand.MESSAGE_SUCCESS, student.getName(),
+        String expectedMessage = String.format(MESSAGE_SUCCESS, student.getName(),
                 targetWeek, attendance);
         Model expectedModel = new ModelManager(model.getTutorsPet(), new UserPrefs());
         FindAttendanceCommand findAttendanceCommand =
@@ -84,8 +96,14 @@ public class FindAttendanceCommandTest {
         Index studentIndex = INDEX_FIRST_ITEM;
         Week targetWeek = VALID_WEEK_1;
 
+        assert moduleClassIndex.getZeroBased() < model.getFilteredModuleClassList().size();
+        assert studentIndex.getZeroBased() < model.getFilteredStudentList().size();
+
         ModuleClass moduleClass = model.getFilteredModuleClassList().get(moduleClassIndex.getZeroBased());
         Student student = model.getFilteredStudentList().get(studentIndex.getZeroBased());
+
+        assert lessonIndex.getZeroBased() < moduleClass.getLessons().size();
+
         Lesson lesson = moduleClass.getLessons().get(lessonIndex.getZeroBased());
 
         assert moduleClass.hasLesson(lesson);
@@ -93,7 +111,7 @@ public class FindAttendanceCommandTest {
         assert lesson.getAttendanceRecordList().hasAttendance(student, targetWeek);
 
         Attendance attendance = lesson.getAttendanceRecordList().getAttendance(student, targetWeek);
-        String expectedMessage = String.format(FindAttendanceCommand.MESSAGE_SUCCESS, student.getName(),
+        String expectedMessage = String.format(MESSAGE_SUCCESS, student.getName(),
                 targetWeek, attendance);
         Model expectedModel = new ModelManager(model.getTutorsPet(), new UserPrefs());
         expectedModel.updateFilteredModuleClassList(c -> c.isSameModuleClass(moduleClass));
@@ -110,7 +128,12 @@ public class FindAttendanceCommandTest {
         Index moduleClassIndex = INDEX_FIRST_ITEM;
         Index lessonIndex = INDEX_FIRST_ITEM;
 
+        assert moduleClassIndex.getZeroBased() < model.getFilteredModuleClassList().size();
+
         ModuleClass moduleClass = model.getFilteredModuleClassList().get(moduleClassIndex.getZeroBased());
+
+        assert lessonIndex.getZeroBased() < moduleClass.getLessons().size();
+
         Lesson lesson = moduleClass.getLessons().get(lessonIndex.getZeroBased());
 
         assert moduleClass.hasLesson(lesson);
@@ -118,7 +141,7 @@ public class FindAttendanceCommandTest {
         FindAttendanceCommand findAttendanceCommand = new FindAttendanceCommand(moduleClassIndex, lessonIndex,
                 INDEX_THIRD_ITEM, VALID_WEEK_1);
 
-        assertCommandFailure(findAttendanceCommand, model, Messages.MESSAGE_INVALID_STUDENT_IN_MODULE_CLASS);
+        assertCommandFailure(findAttendanceCommand, model, MESSAGE_INVALID_STUDENT_IN_MODULE_CLASS);
     }
 
     @Test
@@ -130,12 +153,15 @@ public class FindAttendanceCommandTest {
         FindAttendanceCommand findAttendanceCommand =
                 new FindAttendanceCommand(outOfBoundIndex, lessonIndex, studentIndex, VALID_WEEK_1);
 
-        assertCommandFailure(findAttendanceCommand, model, Messages.MESSAGE_INVALID_MODULE_CLASS_DISPLAYED_INDEX);
+        assertCommandFailure(findAttendanceCommand, model, MESSAGE_INVALID_MODULE_CLASS_DISPLAYED_INDEX);
     }
 
     @Test
     public void execute_invalidLessonIndex_failure() {
         Index moduleClassIndex = INDEX_FIRST_ITEM;
+
+        assert moduleClassIndex.getZeroBased() < model.getFilteredModuleClassList().size();
+
         ModuleClass moduleClass = model.getFilteredModuleClassList().get(moduleClassIndex.getZeroBased());
         Index outOfBoundIndex = Index.fromOneBased(moduleClass.getLessons().size() + 1);
         Index studentIndex = INDEX_FIRST_ITEM;
@@ -143,7 +169,7 @@ public class FindAttendanceCommandTest {
         FindAttendanceCommand findAttendanceCommand =
                 new FindAttendanceCommand(moduleClassIndex, outOfBoundIndex, studentIndex, VALID_WEEK_1);
 
-        assertCommandFailure(findAttendanceCommand, model, Messages.MESSAGE_INVALID_LESSON_DISPLAYED_INDEX);
+        assertCommandFailure(findAttendanceCommand, model, MESSAGE_INVALID_LESSON_DISPLAYED_INDEX);
     }
 
     @Test
@@ -155,7 +181,7 @@ public class FindAttendanceCommandTest {
         FindAttendanceCommand findAttendanceCommand = new FindAttendanceCommand(moduleClassIndex,
                 lessonIndex, outOfBoundIndex, VALID_WEEK_1);
 
-        assertCommandFailure(findAttendanceCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        assertCommandFailure(findAttendanceCommand, model, MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
     }
 
     @Test
@@ -163,15 +189,24 @@ public class FindAttendanceCommandTest {
         Index moduleClassIndex = INDEX_FIRST_ITEM;
         Index lessonIndex = INDEX_FIRST_ITEM;
         Index studentIndex = INDEX_FIRST_ITEM;
-        Lesson lesson = model.getFilteredModuleClassList().get(moduleClassIndex.getZeroBased())
-                .getLessons().get(lessonIndex.getZeroBased());
+
+        assert moduleClassIndex.getZeroBased() < model.getFilteredModuleClassList().size();
+
+        ModuleClass moduleClass = model.getFilteredModuleClassList().get(moduleClassIndex.getZeroBased());
+
+        assert lessonIndex.getZeroBased() < moduleClass.getLessons().size();
+
+        Lesson lesson = moduleClass.getLessons().get(lessonIndex.getZeroBased());
+
+        assert moduleClass.hasLesson(lesson);
+
         Week invalidWeek =
                 new Week(Index.fromOneBased(lesson.getAttendanceRecordList().getAttendanceRecordList().size() + 1));
 
         FindAttendanceCommand findAttendanceCommand =
                 new FindAttendanceCommand(moduleClassIndex, lessonIndex, studentIndex, invalidWeek);
 
-        assertCommandFailure(findAttendanceCommand, model, Messages.MESSAGE_INVALID_WEEK);
+        assertCommandFailure(findAttendanceCommand, model, MESSAGE_INVALID_WEEK);
     }
 
     @Test
@@ -181,8 +216,14 @@ public class FindAttendanceCommandTest {
         Index studentIndex = INDEX_FIRST_ITEM;
         Week week = VALID_WEEK_5;
 
+        assert moduleClassIndex.getZeroBased() < model.getFilteredModuleClassList().size();
+        assert studentIndex.getZeroBased() < model.getFilteredStudentList().size();
+
         ModuleClass moduleClass = model.getFilteredModuleClassList().get(moduleClassIndex.getZeroBased());
         Student student = model.getFilteredStudentList().get(studentIndex.getZeroBased());
+
+        assert lessonIndex.getZeroBased() < moduleClass.getLessons().size();
+
         Lesson lesson = moduleClass.getLessons().get(lessonIndex.getZeroBased());
 
         assert moduleClass.hasLesson(lesson);
@@ -191,7 +232,7 @@ public class FindAttendanceCommandTest {
         FindAttendanceCommand findAttendanceCommand =
                 new FindAttendanceCommand(moduleClassIndex, lessonIndex, studentIndex, week);
 
-        assertCommandFailure(findAttendanceCommand, model, Messages.MESSAGE_MISSING_STUDENT_ATTENDANCE);
+        assertCommandFailure(findAttendanceCommand, model, MESSAGE_MISSING_STUDENT_ATTENDANCE);
     }
 
     @Test
@@ -207,7 +248,7 @@ public class FindAttendanceCommandTest {
         // same value -> returns true
         FindAttendanceCommand duplicateFindAttendanceCommand = new FindAttendanceCommand(INDEX_FIRST_ITEM,
                 INDEX_FIRST_ITEM, INDEX_FIRST_ITEM, week1);
-        assertTrue(findAttendanceCommand.equals(findAttendanceCommand));
+        assertTrue(findAttendanceCommand.equals(duplicateFindAttendanceCommand));
 
         // different type -> returns false
         assertFalse(findAttendanceCommand.equals(5));

--- a/src/test/java/tutorspet/logic/parser/DisplayVenueCommandParserTest.java
+++ b/src/test/java/tutorspet/logic/parser/DisplayVenueCommandParserTest.java
@@ -1,0 +1,60 @@
+package tutorspet.logic.parser;
+
+import static tutorspet.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static tutorspet.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static tutorspet.logic.commands.DisplayVenueCommand.MESSAGE_USAGE;
+import static tutorspet.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static tutorspet.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static tutorspet.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
+
+import org.junit.jupiter.api.Test;
+
+import tutorspet.logic.commands.DisplayVenueCommand;
+
+public class DisplayVenueCommandParserTest {
+
+    private DisplayVenueCommandParser parser = new DisplayVenueCommandParser();
+
+    @Test
+    public void parse_allFieldsPresentSuccess() {
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + " c/1 l/1 ",
+                new DisplayVenueCommand(INDEX_FIRST_ITEM, INDEX_FIRST_ITEM));
+
+        // multiple class indexes - last class index accepted
+        assertParseSuccess(parser, " c/2 l/1 c/1",
+                new DisplayVenueCommand(INDEX_FIRST_ITEM, INDEX_FIRST_ITEM));
+
+        // multiple lesson indexes - last class index accepted
+        assertParseSuccess(parser, " c/1 l/2 l/1",
+                new DisplayVenueCommand(INDEX_FIRST_ITEM, INDEX_FIRST_ITEM));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE);
+
+        // missing class prefix
+        assertParseFailure(parser, " 1 l/1", expectedMessage);
+
+        // missing lesson prefix
+        assertParseFailure(parser, " c/1 1", expectedMessage);
+
+        // missing class index
+        assertParseFailure(parser, " c/ l/1", expectedMessage);
+
+        // missing lesson index
+        assertParseFailure(parser, " c/1 l/", expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE);
+
+        // invalid class index
+        assertParseFailure(parser, " c/& l/1", expectedMessage);
+
+        // invalid lesson index
+        assertParseFailure(parser, " c/1 l/&", expectedMessage);
+    }
+}

--- a/src/test/java/tutorspet/logic/parser/FindAttendanceCommandParserTest.java
+++ b/src/test/java/tutorspet/logic/parser/FindAttendanceCommandParserTest.java
@@ -7,9 +7,11 @@ import static tutorspet.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static tutorspet.logic.commands.CommandTestUtil.VALID_WEEK_VALUE_5;
 import static tutorspet.logic.commands.CommandTestUtil.WEEK_DESC_WEEK_VALUE_3;
 import static tutorspet.logic.commands.CommandTestUtil.WEEK_DESC_WEEK_VALUE_5;
+import static tutorspet.logic.commands.FindAttendanceCommand.MESSAGE_USAGE;
 import static tutorspet.logic.parser.CliSyntax.PREFIX_WEEK;
 import static tutorspet.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static tutorspet.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static tutorspet.model.attendance.Week.MESSAGE_CONSTRAINTS;
 import static tutorspet.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 
 import org.junit.jupiter.api.Test;
@@ -33,19 +35,19 @@ public class FindAttendanceCommandParserTest {
                         expectedWeek));
 
         // multiple class indexes - last class index accepted
-        assertParseSuccess(parser, " c/1 l/1 s/1 c/1"
+        assertParseSuccess(parser, " c/2 l/1 s/1 c/1"
                 + WEEK_DESC_WEEK_VALUE_5,
                 new FindAttendanceCommand(INDEX_FIRST_ITEM, INDEX_FIRST_ITEM, INDEX_FIRST_ITEM,
                         expectedWeek));
 
         // multiple lesson indexes - last class index accepted
-        assertParseSuccess(parser, " c/1 l/1 s/1 l/1"
+        assertParseSuccess(parser, " c/1 l/2 s/1 l/1"
                         + WEEK_DESC_WEEK_VALUE_5,
                 new FindAttendanceCommand(INDEX_FIRST_ITEM, INDEX_FIRST_ITEM, INDEX_FIRST_ITEM,
                         expectedWeek));
 
         // multiple student indexes - last student index accepted
-        assertParseSuccess(parser, " c/1 l/1 s/1 s/1"
+        assertParseSuccess(parser, " c/1 l/1 s/2 s/1"
                         + WEEK_DESC_WEEK_VALUE_5,
                 new FindAttendanceCommand(INDEX_FIRST_ITEM, INDEX_FIRST_ITEM, INDEX_FIRST_ITEM,
                         expectedWeek));
@@ -59,7 +61,7 @@ public class FindAttendanceCommandParserTest {
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindAttendanceCommand.MESSAGE_USAGE);
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE);
 
         // missing class prefix
         assertParseFailure(parser, " 1 l/1 s/1" + WEEK_DESC_WEEK_VALUE_5, expectedMessage);
@@ -88,7 +90,7 @@ public class FindAttendanceCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindAttendanceCommand.MESSAGE_USAGE);
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE);
 
         // invalid class index
         assertParseFailure(parser, " c/& l/1 s/1" + WEEK_DESC_WEEK_VALUE_5, expectedMessage);
@@ -100,9 +102,9 @@ public class FindAttendanceCommandParserTest {
         assertParseFailure(parser, " c/1 l/1 s/&" + WEEK_DESC_WEEK_VALUE_5, expectedMessage);
 
         // invalid week value - lower-bound
-        assertParseFailure(parser, " c/1 l/1 s/1" + INVALID_WEEK_LOWER_BOUND_DESC, Week.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " c/1 l/1 s/1" + INVALID_WEEK_LOWER_BOUND_DESC, MESSAGE_CONSTRAINTS);
 
         // invalid week value - upper-bound
-        assertParseFailure(parser, " c/1 l/1 s/1" + INVALID_WEEK_UPPER_BOUND_DESC, Week.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " c/1 l/1 s/1" + INVALID_WEEK_UPPER_BOUND_DESC, MESSAGE_CONSTRAINTS);
     }
 }

--- a/src/test/java/tutorspet/logic/parser/TutorsPetParserTest.java
+++ b/src/test/java/tutorspet/logic/parser/TutorsPetParserTest.java
@@ -39,6 +39,7 @@ import tutorspet.logic.commands.DeleteAttendanceCommand;
 import tutorspet.logic.commands.DeleteLessonCommand;
 import tutorspet.logic.commands.DeleteModuleClassCommand;
 import tutorspet.logic.commands.DeleteStudentCommand;
+import tutorspet.logic.commands.DisplayVenueCommand;
 import tutorspet.logic.commands.EditAttendanceCommand;
 import tutorspet.logic.commands.EditAttendanceCommand.EditAttendanceDescriptor;
 import tutorspet.logic.commands.EditLessonCommand;
@@ -337,6 +338,21 @@ public class TutorsPetParserTest {
     public void parseCommand_reset() throws Exception {
         assertTrue(parser.parseCommand(ResetCommand.COMMAND_WORD) instanceof ResetCommand);
         assertTrue(parser.parseCommand(ResetCommand.COMMAND_WORD + NON_EMPTY_STRING) instanceof ResetCommand);
+    }
+
+    @Test
+    public void parseCommand_displayVenue() throws Exception {
+        DisplayVenueCommand expectedCommand = new DisplayVenueCommand(INDEX_FIRST_ITEM, INDEX_FIRST_ITEM);
+        DisplayVenueCommand command =
+                (DisplayVenueCommand) parser.parseCommand(DisplayVenueCommand.COMMAND_WORD + " "
+                        + PREFIX_CLASS_INDEX + INDEX_FIRST_ITEM.getOneBased() + " "
+                        + PREFIX_LESSON_INDEX + INDEX_FIRST_ITEM.getOneBased());
+        DisplayVenueCommand altCommand =
+                (DisplayVenueCommand) parser.parseCommand(DisplayVenueCommand.COMMAND_WORD + " "
+                        + PREFIX_LESSON_INDEX + INDEX_FIRST_ITEM.getOneBased() + " "
+                        + PREFIX_CLASS_INDEX + INDEX_FIRST_ITEM.getOneBased());
+        assertEquals(expectedCommand, command);
+        assertEquals(expectedCommand, altCommand);
     }
 
     @Test

--- a/src/test/java/tutorspet/model/lesson/LessonTest.java
+++ b/src/test/java/tutorspet/model/lesson/LessonTest.java
@@ -144,6 +144,18 @@ public class LessonTest {
     }
 
     @Test
+    public void printLesson_returnsCorrectFormat() {
+        Lesson lesson = new Lesson(VALID_START_TIME, VALID_END_TIME, VALID_DAY_WED_LESSON_WED_2_TO_4,
+                VALID_NUMBER_OF_OCCURRENCES, VALID_VENUE, VALID_ATTENDANCE_RECORD_LIST);
+        String expectedString = (new StringBuilder()).append(CommandTestUtil.VALID_DAY_WED_LESSON_WED_2_TO_4)
+                .append(" ")
+                .append(TIME_FORMATTER.format(VALID_START_TIME))
+                .append(" to ")
+                .append(TIME_FORMATTER.format(VALID_END_TIME)).toString();
+        assertEquals(expectedString, lesson.printLesson());
+    }
+
+    @Test
     public void equals() {
         // same object -> returns true
         assertTrue(LESSON_FRI_8_TO_10.equals(LESSON_FRI_8_TO_10));


### PR DESCRIPTION
Closes #148 

Displaying venue in the command result box allows users to copy URLs easily.

<img width="771" alt="Screenshot 2020-10-20 at 2 19 35 AM" src="https://user-images.githubusercontent.com/65149295/96495764-dabc0f80-127a-11eb-9e40-7fb4cc804dda.png">
